### PR TITLE
Bundle KaTeX locally for equation rendering

### DIFF
--- a/components/Equation.tsx
+++ b/components/Equation.tsx
@@ -6,7 +6,13 @@ type Props = { tex: string; block?: boolean };
 
 // Dynamically load native math view only on native
 let NativeMathView: any = null;
-if (Platform.OS !== 'web') {
+let katex: any = null;
+if (Platform.OS === 'web') {
+  try {
+    katex = require('katex');
+    require('katex/dist/katex.min.css');
+  } catch {}
+} else {
   try {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     NativeMathView = require('react-native-math-view').default;
@@ -15,12 +21,10 @@ if (Platform.OS !== 'web') {
 
 export default function Equation({ tex, block = true }: Props) {
   if (Platform.OS === 'web') {
-    // Use global KaTeX loaded from CDN in web/index.html
     const html = useMemo(() => {
-      const w = window as any;
-      if (w?.katex?.renderToString) {
+      if (katex?.renderToString) {
         try {
-          return w.katex.renderToString(tex, {
+          return katex.renderToString(tex, {
             displayMode: block,
             throwOnError: false,
             strict: 'ignore',

--- a/web/index.html
+++ b/web/index.html
@@ -8,15 +8,6 @@
     />
     <title>QM Edu</title>
 
-    <!-- KaTeX CSS + core script (global window.katex) -->
-    <link
-      rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.css"
-    />
-    <script
-      defer
-      src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js"
-    ></script>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary
- remove KaTeX CDN tags from web entrypoint
- import and use KaTeX directly from node modules in Equation component

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx tsc -p tsconfig.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_68b7109e6c1083229d98ac3984cebeef