### PR TITLE
docs: add ten quantum concept explanations

### DIFF
--- a/docs/ten-quantum-concepts.md
+++ b/docs/ten-quantum-concepts.md
@@ -1,0 +1,140 @@
+# Ten Quantum-Mechanics Concepts
+
+Here are ten additional quantum-mechanics concepts, each explained with a technical ("Standard Concept") and an analogy-rich ("Simple Version") discussion. Each standard discussion includes a reference to a book or paper for further reading.
+
+---
+
+## 1. Wavefunction and Born Rule
+
+**Standard Concept**
+
+The wavefunction $\psi(\mathbf{r}, t)$ is a complex-valued function encapsulating all information about a quantum system’s state. Born’s rule states that the probability density of finding a particle at position $\mathbf{r}$ is $|\psi(\mathbf{r}, t)|^2$. This interpretation is foundational for calculating measurable predictions.  
+*Reference:* J. J. Sakurai and J. Napolitano, *Modern Quantum Mechanics*, 2nd ed. (2011), Chapter 1.
+
+**Simple Version**
+
+Think of the wavefunction as a magical fog that surrounds a particle. The fog is thicker in some spots than others; when you check to see where the particle is, you’re more likely to find it where the fog is thick. The Born rule simply says, “square the fog’s thickness” (its intensity) to get the odds of finding the particle there. We never see the fog directly, but it tells us how likely the particle is to be in any region.
+
+---
+
+## 2. Heisenberg Uncertainty Principle
+
+**Standard Concept**
+
+The Heisenberg uncertainty principle expresses the intrinsic limitations in simultaneously knowing pairs of conjugate variables, such as position and momentum. For position $x$ and momentum $p$, the product of uncertainties satisfies $\Delta x\, \Delta p \geq \tfrac{\hbar}{2}$. This arises from the non-commuting nature of the corresponding operators.  
+*Reference:* L. E. Ballentine, *Quantum Mechanics: A Modern Development* (1998), Chapter 3.
+
+**Simple Version**
+
+It’s like trying to take a perfect photo of a soccer ball while it’s rolling. If you snap a fast photo to pinpoint its location, you blur how fast it’s moving. If you take a long-exposure photo to measure speed, the location becomes blurry. Quantum particles obey this rule naturally: knowing exactly where they are makes it impossible to know exactly how fast they’re going, and vice versa.
+
+---
+
+## 3. Superposition Principle
+
+**Standard Concept**
+
+A quantum system can exist in a linear combination of basis states. If $|\phi_1\rangle$ and $|\phi_2\rangle$ are valid states, any $|\psi\rangle = \alpha|\phi_1\rangle + \beta|\phi_2\rangle$ (with complex coefficients $\alpha, \beta$) is also a valid state. Superposition enables phenomena such as interference and is central to quantum information processing.  
+*Reference:* D. J. Griffiths and D. F. Schroeter, *Introduction to Quantum Mechanics*, 3rd ed. (2018), Section 3.1.
+
+**Simple Version**
+
+Imagine a light switch that can be both “on” and “off” at the same time—until you check. A quantum superposition is like that: the system “tries out” different possibilities at once. Only when you look do you get a single outcome. It’s like a coin spinning in the air—during the spin, it’s both heads and tails, only revealing one when it lands and you see it.
+
+---
+
+## 4. Time-Dependent Schrödinger Equation
+
+**Standard Concept**
+
+The time evolution of a non-relativistic quantum system is governed by the time-dependent Schrödinger equation: $i\hbar\tfrac{\partial}{\partial t}|\psi(t)\rangle = \hat{H}|\psi(t)\rangle$, where $\hat{H}$ is the Hamiltonian operator representing the total energy. Solutions evolve unitarily, preserving normalization and encapsulating the dynamical behavior of the system.  
+*Reference:* J. J. Sakurai and J. Napolitano, *Modern Quantum Mechanics*, 2nd ed. (2011), Chapter 2.
+
+**Simple Version**
+
+This equation is like a recipe for how a quantum system changes over time. If you know the “ingredient list” (the Hamiltonian), the Schrödinger equation tells you how the system’s “flavor” (the wavefunction) will mix and transform. Imagine stirring a pot of soup: the equation is the rule that decides how each ingredient diffuses and interacts as the soup simmers.
+
+---
+
+## 5. Quantum Tunneling
+
+**Standard Concept**
+
+Quantum tunneling allows a particle to cross a potential barrier even when its classical energy is lower than the barrier height. The probability of tunneling depends exponentially on the barrier’s width and height. This phenomenon arises from the wave nature of particles and solutions to the Schrödinger equation in regions where classically the wave would be exponentially decaying.  
+*Reference:* D. J. Griffiths and D. F. Schroeter, *Introduction to Quantum Mechanics*, 3rd ed. (2018), Section 8.3.
+
+**Simple Version**
+
+Imagine a ball rolling toward a hill. Classically, if the ball doesn’t have enough energy, it just rolls back. Quantum tunneling says the ball can sometimes magically appear on the other side—even though it didn’t go over the top. It “tunnels” through. It’s a bit like having a secret passage through the hill that only tiny quantum balls can use.
+
+---
+
+## 6. Spin and Pauli Matrices
+
+**Standard Concept**
+
+Spin is an intrinsic form of angular momentum in quantum particles, described by operators obeying SU(2) algebra. For spin-$\tfrac{1}{2}$ particles, observables are represented by Pauli matrices $\sigma_x, \sigma_y, \sigma_z$. Measurements yield discrete outcomes, and their commutation relations $[\sigma_i, \sigma_j] = 2i\epsilon_{ijk}\sigma_k$ define the spin’s quantized behavior.  
+*Reference:* A. Szabo and N. S. Ostlund, *Modern Quantum Chemistry* (1996), Chapter 2.
+
+**Simple Version**
+
+Picture a tiny top spinning. Quantum spin is like an internal rotation, but it doesn’t stop or change size—it’s built in. Pauli matrices are like switches that tell you how the top is spinning along different directions. When you measure the spin, you get only two answers: “up” or “down.” It’s like asking the top, “Are you twirling up or down?” and it responds with only one of those two answers.
+
+---
+
+## 7. Quantum Entanglement
+
+**Standard Concept**
+
+Entanglement occurs when the state of one particle cannot be described independently of another, even when separated by large distances. Measurements on entangled subsystems show correlations stronger than classically allowed, violating Bell inequalities. Entanglement is a resource for quantum computation and communication.  
+*Reference:* R. Horodecki, P. Horodecki, M. Horodecki, and K. Horodecki, “Quantum entanglement,” *Rev. Mod. Phys.* **81**, 865 (2009).
+
+**Simple Version**
+
+Imagine two magic dice that always show matching numbers no matter how far apart they are. If you roll one die and see a 6, the other instantly shows a 6, too, even if it’s on the other side of the world. That’s entanglement: the particles are “linked” so that learning about one tells you something about the other, faster than any message could travel.
+
+---
+
+## 8. Measurement and Wavefunction Collapse
+
+**Standard Concept**
+
+Quantum measurement projects a system’s state onto an eigenstate of the measurement operator. The wavefunction collapse postulate states that after measurement, the system instantaneously adopts the eigenstate corresponding to the observed eigenvalue, and subsequent probabilities are computed from that post-measurement state.  
+*Reference:* P. A. M. Dirac, *The Principles of Quantum Mechanics*, 4th ed. (1958), Chapter VIII.
+
+**Simple Version**
+
+Before you peek, a quantum object tries many outfits at once. When you look, it freezes wearing just one outfit. That sudden change is “wavefunction collapse.” The act of checking forces the object to commit to a single choice, like a shy actor stepping into the spotlight and picking a costume to wear.
+
+---
+
+## 9. Hilbert Space and Bra-Ket Notation
+
+**Standard Concept**
+
+Quantum states reside in a complex Hilbert space, a complete vector space with an inner product. Dirac’s bra-ket notation uses $|\psi\rangle$ for state vectors (kets) and $\langle\phi|$ for dual vectors (bras). Inner products $\langle\phi|\psi\rangle$ produce complex numbers representing amplitudes, and linear operators act on kets to change states or extract observables.  
+*Reference:* P. A. M. Dirac, *The Principles of Quantum Mechanics*, 4th ed. (1958), Chapter II.
+
+**Simple Version**
+
+Think of a Hilbert space as a big room where every point is a possible state for your quantum toy. Bra-ket notation is just a fancy way of writing “vectors” and “functions” that live in this room. A “ket” $|\psi\rangle$ is like pointing to a spot in the room, while a “bra” $\langle\phi|$ is like shining a beam that measures something about that spot. When you combine them $\langle\phi|\psi\rangle$, you get a number that tells you how much the beam and spot agree.
+
+---
+
+## 10. Feynman Path Integrals
+
+**Standard Concept**
+
+The path integral formulation expresses a quantum amplitude as a sum over all possible paths connecting initial and final states:
+$$
+\langle x_f, t_f | x_i, t_i \rangle = \int \mathcal{D}[x(t)] \; e^{\frac{i}{\hbar} S[x(t)]}.
+$$
+Here, $S[x(t)]$ is the classical action. Each path contributes a phase $e^{iS/\hbar}$, and observable quantities emerge from interference among these paths.  
+*Reference:* R. P. Feynman and A. R. Hibbs, *Quantum Mechanics and Path Integrals* (1965), Chapter 2.
+
+**Simple Version**
+
+To figure out where a quantum particle goes, imagine it trying every possible route from start to finish. Some paths wiggle a lot, others are straight. Each path gets a special “phase tag,” and when you add up all the tags, most cancel out except the ones near the classical path. It’s like having a zillion reporters shout what route the particle took; the voices that agree get louder while the rest cancel each other out, revealing the most likely path.
+
+---
+


### PR DESCRIPTION
## Summary
- add documentation covering ten quantum-mechanics concepts with standard and child-friendly explanations

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b72ff0c16c83228242699994e4cc79