### PR TITLE
Fix double headers on concept pages

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -6,11 +6,12 @@ export default function RootLayout() {
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
       <SafeAreaView style={{ flex: 1, backgroundColor: '#0e1a23' }}>
-        <Stack screenOptions={{
-          headerStyle: { backgroundColor: '#0b7f8a' },
-          headerTintColor: 'white',
-          contentStyle: { backgroundColor: '#0e1a23' }
-        }}/>
+        <Stack
+          screenOptions={{
+            headerShown: false,
+            contentStyle: { backgroundColor: '#0e1a23' },
+          }}
+        />
       </SafeAreaView>
     </GestureHandlerRootView>
   );

--- a/app/concepts/_layout.tsx
+++ b/app/concepts/_layout.tsx
@@ -1,0 +1,23 @@
+import { Stack, Link } from 'expo-router';
+import { Pressable, Text } from 'react-native';
+
+export default function ConceptsLayout() {
+  return (
+    <Stack
+      screenOptions={({ route }) => ({
+        headerStyle: { backgroundColor: '#0b7f8a' },
+        headerTintColor: 'white',
+        contentStyle: { backgroundColor: '#0e1a23' },
+        headerLeft: route.name !== 'index' ? () => (
+          <Link href="/concepts" asChild>
+            <Pressable style={{ padding: 4 }}>
+              <Text style={{ color: 'white', fontSize: 18 }}>{'\u2190'}</Text>
+            </Pressable>
+          </Link>
+        ) : undefined,
+      })}
+    >
+      <Stack.Screen name="index" options={{ title: 'concepts' }} />
+    </Stack>
+  );
+}

--- a/app/concepts/feynman-path-integrals.tsx
+++ b/app/concepts/feynman-path-integrals.tsx
@@ -1,0 +1,28 @@
+import { View, Text } from 'react-native';
+import TwoPane from '../../components/TwoPane';
+import ConceptCard from '../../components/ConceptCard';
+import Equation from '../../components/Equation';
+
+export default function FeynmanPathIntegrals() {
+  return (
+    <View style={{ flex:1, padding:16, gap:12 }}>
+      <TwoPane
+        standard={
+          <ConceptCard title="Standard Concept">
+            <Text style={{ color:'#b9d7dc' }}>
+              {'The path integral formulation sums over all possible paths connecting initial and final states, each weighted by the phase e^{iS/ħ}. (Feynman & Hibbs, 1965)'}
+            </Text>
+            <Equation tex={'\\langle x_f,t_f | x_i,t_i \\rangle = \\int \\mathcal{D}[x(t)] e^{\\tfrac{i}{\\hbar}S[x(t)]}'} />
+          </ConceptCard>
+        }
+        simple={
+          <ConceptCard title="Simple Version">
+            <Text style={{ color:'#b9d7dc' }}>
+              To know where a particle goes, imagine it trying every route. Each path adds a little voice; the paths that agree get louder while the rest cancel, revealing the most likely route.
+            </Text>
+          </ConceptCard>
+        }
+      />
+    </View>
+  );
+}

--- a/app/concepts/heisenberg-uncertainty.tsx
+++ b/app/concepts/heisenberg-uncertainty.tsx
@@ -1,22 +1,24 @@
 import { View, Text } from 'react-native';
 import TwoPane from '../../components/TwoPane';
 import ConceptCard from '../../components/ConceptCard';
+import Equation from '../../components/Equation';
 
-export default function Entanglement() {
+export default function HeisenbergUncertainty() {
   return (
     <View style={{ flex:1, padding:16, gap:12 }}>
       <TwoPane
         standard={
           <ConceptCard title="Standard Concept">
             <Text style={{ color:'#b9d7dc' }}>
-              Entanglement occurs when the state of one particle cannot be described independently of another, even when separated by large distances. Measurements on entangled subsystems show correlations stronger than classically allowed.
+              The Heisenberg uncertainty principle limits simultaneous knowledge of conjugate variables like position and momentum.
             </Text>
+            <Equation tex={'\\Delta x\\, \\Delta p \\ge \\tfrac{\\hbar}{2}'} />
           </ConceptCard>
         }
         simple={
           <ConceptCard title="Simple Version">
             <Text style={{ color:'#b9d7dc' }}>
-              Imagine two magic dice that always show matching numbers no matter how far apart they are. Rolling one instantly tells you the result of the other. That's entanglement.
+              It's like photographing a rolling soccer ball. A quick snapshot shows where it is but blurs its speed; a long exposure shows speed but blurs position.
             </Text>
           </ConceptCard>
         }

--- a/app/concepts/hilbert-space-bra-ket.tsx
+++ b/app/concepts/hilbert-space-bra-ket.tsx
@@ -1,22 +1,24 @@
 import { View, Text } from 'react-native';
 import TwoPane from '../../components/TwoPane';
 import ConceptCard from '../../components/ConceptCard';
+import Equation from '../../components/Equation';
 
-export default function Entanglement() {
+export default function HilbertSpaceBraKet() {
   return (
     <View style={{ flex:1, padding:16, gap:12 }}>
       <TwoPane
         standard={
           <ConceptCard title="Standard Concept">
             <Text style={{ color:'#b9d7dc' }}>
-              Entanglement occurs when the state of one particle cannot be described independently of another, even when separated by large distances. Measurements on entangled subsystems show correlations stronger than classically allowed.
+              Quantum states reside in a complex Hilbert space, a complete vector space with an inner product. Dirac's bra-ket notation uses |\u03c8\u27e9 for kets and \u27e8\u03c6| for bras.
             </Text>
+            <Equation tex={'\\langle\\phi|\\psi\\rangle'} />
           </ConceptCard>
         }
         simple={
           <ConceptCard title="Simple Version">
             <Text style={{ color:'#b9d7dc' }}>
-              Imagine two magic dice that always show matching numbers no matter how far apart they are. Rolling one instantly tells you the result of the other. That's entanglement.
+              Think of a Hilbert space as a big room of possible states. A ket points to a spot in the room, and a bra is like a beam measuring that spot. Their combination gives a number telling how much they agree.
             </Text>
           </ConceptCard>
         }

--- a/app/concepts/index.tsx
+++ b/app/concepts/index.tsx
@@ -2,9 +2,17 @@ import { Link } from 'expo-router';
 import { View, Text, Pressable } from 'react-native';
 
 const items = [
-  { path: '/concepts/superposition', title: 'Superposition' },
-  { path: '/concepts/double-slit', title: 'Double Slit' },
-  { path: '/concepts/entanglement', title: 'Entanglement' },
+  { path: '/concepts/double-slit', title: 'Double-Slit Experiment' },
+  { path: '/concepts/wavefunction-born-rule', title: 'Wavefunction & Born Rule' },
+  { path: '/concepts/heisenberg-uncertainty', title: 'Heisenberg Uncertainty' },
+  { path: '/concepts/superposition', title: 'Superposition Principle' },
+  { path: '/concepts/time-dependent-schrodinger', title: 'Time-Dependent Schr\u00f6dinger' },
+  { path: '/concepts/quantum-tunneling', title: 'Quantum Tunneling' },
+  { path: '/concepts/spin-and-pauli-matrices', title: 'Spin & Pauli Matrices' },
+  { path: '/concepts/entanglement', title: 'Quantum Entanglement' },
+  { path: '/concepts/measurement-collapse', title: 'Measurement & Collapse' },
+  { path: '/concepts/hilbert-space-bra-ket', title: 'Hilbert Space & Bra–Ket' },
+  { path: '/concepts/feynman-path-integrals', title: 'Feynman Path Integrals' },
 ];
 
 export default function ConceptsIndex() {

--- a/app/concepts/measurement-collapse.tsx
+++ b/app/concepts/measurement-collapse.tsx
@@ -2,21 +2,21 @@ import { View, Text } from 'react-native';
 import TwoPane from '../../components/TwoPane';
 import ConceptCard from '../../components/ConceptCard';
 
-export default function Entanglement() {
+export default function MeasurementCollapse() {
   return (
     <View style={{ flex:1, padding:16, gap:12 }}>
       <TwoPane
         standard={
           <ConceptCard title="Standard Concept">
             <Text style={{ color:'#b9d7dc' }}>
-              Entanglement occurs when the state of one particle cannot be described independently of another, even when separated by large distances. Measurements on entangled subsystems show correlations stronger than classically allowed.
+              Quantum measurement projects a system's state onto an eigenstate of the measurement operator. After measurement, the wavefunction collapses to the observed eigenstate.
             </Text>
           </ConceptCard>
         }
         simple={
           <ConceptCard title="Simple Version">
             <Text style={{ color:'#b9d7dc' }}>
-              Imagine two magic dice that always show matching numbers no matter how far apart they are. Rolling one instantly tells you the result of the other. That's entanglement.
+              Before you peek, a quantum object tries many outfits at once. Looking forces it to freeze wearing one outfit, the wavefunction collapse.
             </Text>
           </ConceptCard>
         }

--- a/app/concepts/quantum-tunneling.tsx
+++ b/app/concepts/quantum-tunneling.tsx
@@ -2,21 +2,21 @@ import { View, Text } from 'react-native';
 import TwoPane from '../../components/TwoPane';
 import ConceptCard from '../../components/ConceptCard';
 
-export default function Entanglement() {
+export default function QuantumTunneling() {
   return (
     <View style={{ flex:1, padding:16, gap:12 }}>
       <TwoPane
         standard={
           <ConceptCard title="Standard Concept">
             <Text style={{ color:'#b9d7dc' }}>
-              Entanglement occurs when the state of one particle cannot be described independently of another, even when separated by large distances. Measurements on entangled subsystems show correlations stronger than classically allowed.
+              Quantum tunneling allows a particle to pass through a potential barrier even when its energy is lower than the barrier height. The probability depends exponentially on the barrier's width and height.
             </Text>
           </ConceptCard>
         }
         simple={
           <ConceptCard title="Simple Version">
             <Text style={{ color:'#b9d7dc' }}>
-              Imagine two magic dice that always show matching numbers no matter how far apart they are. Rolling one instantly tells you the result of the other. That's entanglement.
+              Imagine a ball rolling toward a hill. Even if it lacks enough energy to go over, quantum mechanics lets it sometimes appear on the other side as if through a secret tunnel.
             </Text>
           </ConceptCard>
         }

--- a/app/concepts/spin-and-pauli-matrices.tsx
+++ b/app/concepts/spin-and-pauli-matrices.tsx
@@ -1,22 +1,24 @@
 import { View, Text } from 'react-native';
 import TwoPane from '../../components/TwoPane';
 import ConceptCard from '../../components/ConceptCard';
+import Equation from '../../components/Equation';
 
-export default function Entanglement() {
+export default function SpinAndPauliMatrices() {
   return (
     <View style={{ flex:1, padding:16, gap:12 }}>
       <TwoPane
         standard={
           <ConceptCard title="Standard Concept">
             <Text style={{ color:'#b9d7dc' }}>
-              Entanglement occurs when the state of one particle cannot be described independently of another, even when separated by large distances. Measurements on entangled subsystems show correlations stronger than classically allowed.
+              Spin is an intrinsic form of angular momentum described by operators obeying SU(2) algebra. For spin-1/2 particles, observables are represented by the Pauli matrices.
             </Text>
+            <Equation tex={'[\\sigma_i,\\sigma_j]=2i\\varepsilon_{ijk}\\sigma_k'} />
           </ConceptCard>
         }
         simple={
           <ConceptCard title="Simple Version">
             <Text style={{ color:'#b9d7dc' }}>
-              Imagine two magic dice that always show matching numbers no matter how far apart they are. Rolling one instantly tells you the result of the other. That's entanglement.
+              Picture a tiny top that never stops spinning. Pauli matrices are like switches telling how it's spinning along different directions. Measuring gives only "up" or "down".
             </Text>
           </ConceptCard>
         }

--- a/app/concepts/superposition.tsx
+++ b/app/concepts/superposition.tsx
@@ -2,29 +2,26 @@ import { View, Text } from 'react-native';
 import TwoPane from '../../components/TwoPane';
 import ConceptCard from '../../components/ConceptCard';
 import Equation from '../../components/Equation';
-import SpinToy from '../../components/SpinToy';
 
 export default function Superposition() {
   return (
     <View style={{ flex:1, padding:16, gap:12 }}>
       <TwoPane
         standard={
-          <ConceptCard title="Definition">
+          <ConceptCard title="Standard Concept">
             <Text style={{ color:'#b9d7dc' }}>
-              A state |ψ⟩ is a linear combination of basis states. For a spin‑½ in the z‑basis:
+              A quantum system can exist in a linear combination of basis states. If |φ₁⟩ and |φ₂⟩ are valid states, any |
+              ψ⟩ = α|φ₁⟩ + β|φ₂⟩ with complex coefficients α, β is also a valid state, enabling interference phenomena.
             </Text>
-            <Equation tex={'\\lvert \\psi \\rangle = \\alpha \\lvert \\uparrow \\rangle + \\beta \\lvert \\downarrow \\rangle,\\quad \\lvert\\alpha\\rvert^2+\\lvert\\beta\\rvert^2=1'} />
-            <ConceptCard title="Measurement rule">
-              <Equation tex={'P(\\uparrow)=\\lvert\\alpha\\rvert^2,\\quad P(\\downarrow)=\\lvert\\beta\\rvert^2'}/>
-            </ConceptCard>
+            <Equation tex={'\\lvert \\psi \\rangle = \\alpha \\lvert \\phi_1 \\rangle + \\beta \\lvert \\phi_2 \\rangle'} />
           </ConceptCard>
         }
         simple={
-          <ConceptCard title="Intuition">
+          <ConceptCard title="Simple Version">
             <Text style={{ color:'#b9d7dc' }}>
-              Think of the state as a direction on a sphere. The closer it points to ↑, the more likely you’ll read ↑.
+              Imagine a light switch that can be both "on" and "off" at the same time until you look. The system tries many
+              possibilities at once and settles on one only when checked, like a spinning coin revealing heads or tails when it lands.
             </Text>
-            <SpinToy />
           </ConceptCard>
         }
       />

--- a/app/concepts/time-dependent-schrodinger.tsx
+++ b/app/concepts/time-dependent-schrodinger.tsx
@@ -1,22 +1,24 @@
 import { View, Text } from 'react-native';
 import TwoPane from '../../components/TwoPane';
 import ConceptCard from '../../components/ConceptCard';
+import Equation from '../../components/Equation';
 
-export default function Entanglement() {
+export default function TimeDependentSchrodinger() {
   return (
     <View style={{ flex:1, padding:16, gap:12 }}>
       <TwoPane
         standard={
           <ConceptCard title="Standard Concept">
             <Text style={{ color:'#b9d7dc' }}>
-              Entanglement occurs when the state of one particle cannot be described independently of another, even when separated by large distances. Measurements on entangled subsystems show correlations stronger than classically allowed.
+              The time evolution of a non-relativistic quantum system is governed by the time-dependent Schr\u00f6dinger equation.
             </Text>
+            <Equation tex={'i\\hbar\\tfrac{\\partial}{\\partial t}\\lvert\\psi(t)\\rangle = \\hat{H}\\lvert\\psi(t)\\rangle'} />
           </ConceptCard>
         }
         simple={
           <ConceptCard title="Simple Version">
             <Text style={{ color:'#b9d7dc' }}>
-              Imagine two magic dice that always show matching numbers no matter how far apart they are. Rolling one instantly tells you the result of the other. That's entanglement.
+              This equation is like a recipe telling how a quantum system changes over time, mixing ingredients set by the Hamiltonian just like a soup simmering.
             </Text>
           </ConceptCard>
         }

--- a/app/concepts/wavefunction-born-rule.tsx
+++ b/app/concepts/wavefunction-born-rule.tsx
@@ -1,0 +1,28 @@
+import { View, Text } from 'react-native';
+import TwoPane from '../../components/TwoPane';
+import ConceptCard from '../../components/ConceptCard';
+import Equation from '../../components/Equation';
+
+export default function WavefunctionBornRule() {
+  return (
+    <View style={{ flex:1, padding:16, gap:12 }}>
+      <TwoPane
+        standard={
+          <ConceptCard title="Standard Concept">
+            <Text style={{ color:'#b9d7dc' }}>
+              The wavefunction \u03c8(r,t) encapsulates all information about a quantum system. Born's rule states that the probability density of finding a particle at position r is |\u03c8(r,t)|\u00b2.
+            </Text>
+            <Equation tex={'P(\\mathbf{r},t)=\\lvert\\psi(\\mathbf{r},t)\\rvert^2'} />
+          </ConceptCard>
+        }
+        simple={
+          <ConceptCard title="Simple Version">
+            <Text style={{ color:'#b9d7dc' }}>
+              Think of the wavefunction as a magical fog around the particle. Where the fog is thick, you're more likely to find the particle. Squaring the fog's thickness gives the chance of finding it there.
+            </Text>
+          </ConceptCard>
+        }
+      />
+    </View>
+  );
+}

--- a/docs/ten-quantum-concepts.md
+++ b/docs/ten-quantum-concepts.md
@@ -1,0 +1,140 @@
+# Ten Quantum-Mechanics Concepts
+
+Here are ten additional quantum-mechanics concepts, each explained with a technical ("Standard Concept") and an analogy-rich ("Simple Version") discussion. Each standard discussion includes a reference to a book or paper for further reading.
+
+---
+
+## 1. Wavefunction and Born Rule
+
+**Standard Concept**
+
+The wavefunction $\psi(\mathbf{r}, t)$ is a complex-valued function encapsulating all information about a quantum system’s state. Born’s rule states that the probability density of finding a particle at position $\mathbf{r}$ is $|\psi(\mathbf{r}, t)|^2$. This interpretation is foundational for calculating measurable predictions.  
+*Reference:* J. J. Sakurai and J. Napolitano, *Modern Quantum Mechanics*, 2nd ed. (2011), Chapter 1.
+
+**Simple Version**
+
+Think of the wavefunction as a magical fog that surrounds a particle. The fog is thicker in some spots than others; when you check to see where the particle is, you’re more likely to find it where the fog is thick. The Born rule simply says, “square the fog’s thickness” (its intensity) to get the odds of finding the particle there. We never see the fog directly, but it tells us how likely the particle is to be in any region.
+
+---
+
+## 2. Heisenberg Uncertainty Principle
+
+**Standard Concept**
+
+The Heisenberg uncertainty principle expresses the intrinsic limitations in simultaneously knowing pairs of conjugate variables, such as position and momentum. For position $x$ and momentum $p$, the product of uncertainties satisfies $\Delta x\, \Delta p \geq \tfrac{\hbar}{2}$. This arises from the non-commuting nature of the corresponding operators.  
+*Reference:* L. E. Ballentine, *Quantum Mechanics: A Modern Development* (1998), Chapter 3.
+
+**Simple Version**
+
+It’s like trying to take a perfect photo of a soccer ball while it’s rolling. If you snap a fast photo to pinpoint its location, you blur how fast it’s moving. If you take a long-exposure photo to measure speed, the location becomes blurry. Quantum particles obey this rule naturally: knowing exactly where they are makes it impossible to know exactly how fast they’re going, and vice versa.
+
+---
+
+## 3. Superposition Principle
+
+**Standard Concept**
+
+A quantum system can exist in a linear combination of basis states. If $|\phi_1\rangle$ and $|\phi_2\rangle$ are valid states, any $|\psi\rangle = \alpha|\phi_1\rangle + \beta|\phi_2\rangle$ (with complex coefficients $\alpha, \beta$) is also a valid state. Superposition enables phenomena such as interference and is central to quantum information processing.  
+*Reference:* D. J. Griffiths and D. F. Schroeter, *Introduction to Quantum Mechanics*, 3rd ed. (2018), Section 3.1.
+
+**Simple Version**
+
+Imagine a light switch that can be both “on” and “off” at the same time—until you check. A quantum superposition is like that: the system “tries out” different possibilities at once. Only when you look do you get a single outcome. It’s like a coin spinning in the air—during the spin, it’s both heads and tails, only revealing one when it lands and you see it.
+
+---
+
+## 4. Time-Dependent Schrödinger Equation
+
+**Standard Concept**
+
+The time evolution of a non-relativistic quantum system is governed by the time-dependent Schrödinger equation: $i\hbar\tfrac{\partial}{\partial t}|\psi(t)\rangle = \hat{H}|\psi(t)\rangle$, where $\hat{H}$ is the Hamiltonian operator representing the total energy. Solutions evolve unitarily, preserving normalization and encapsulating the dynamical behavior of the system.  
+*Reference:* J. J. Sakurai and J. Napolitano, *Modern Quantum Mechanics*, 2nd ed. (2011), Chapter 2.
+
+**Simple Version**
+
+This equation is like a recipe for how a quantum system changes over time. If you know the “ingredient list” (the Hamiltonian), the Schrödinger equation tells you how the system’s “flavor” (the wavefunction) will mix and transform. Imagine stirring a pot of soup: the equation is the rule that decides how each ingredient diffuses and interacts as the soup simmers.
+
+---
+
+## 5. Quantum Tunneling
+
+**Standard Concept**
+
+Quantum tunneling allows a particle to cross a potential barrier even when its classical energy is lower than the barrier height. The probability of tunneling depends exponentially on the barrier’s width and height. This phenomenon arises from the wave nature of particles and solutions to the Schrödinger equation in regions where classically the wave would be exponentially decaying.  
+*Reference:* D. J. Griffiths and D. F. Schroeter, *Introduction to Quantum Mechanics*, 3rd ed. (2018), Section 8.3.
+
+**Simple Version**
+
+Imagine a ball rolling toward a hill. Classically, if the ball doesn’t have enough energy, it just rolls back. Quantum tunneling says the ball can sometimes magically appear on the other side—even though it didn’t go over the top. It “tunnels” through. It’s a bit like having a secret passage through the hill that only tiny quantum balls can use.
+
+---
+
+## 6. Spin and Pauli Matrices
+
+**Standard Concept**
+
+Spin is an intrinsic form of angular momentum in quantum particles, described by operators obeying SU(2) algebra. For spin-$\tfrac{1}{2}$ particles, observables are represented by Pauli matrices $\sigma_x, \sigma_y, \sigma_z$. Measurements yield discrete outcomes, and their commutation relations $[\sigma_i, \sigma_j] = 2i\epsilon_{ijk}\sigma_k$ define the spin’s quantized behavior.  
+*Reference:* A. Szabo and N. S. Ostlund, *Modern Quantum Chemistry* (1996), Chapter 2.
+
+**Simple Version**
+
+Picture a tiny top spinning. Quantum spin is like an internal rotation, but it doesn’t stop or change size—it’s built in. Pauli matrices are like switches that tell you how the top is spinning along different directions. When you measure the spin, you get only two answers: “up” or “down.” It’s like asking the top, “Are you twirling up or down?” and it responds with only one of those two answers.
+
+---
+
+## 7. Quantum Entanglement
+
+**Standard Concept**
+
+Entanglement occurs when the state of one particle cannot be described independently of another, even when separated by large distances. Measurements on entangled subsystems show correlations stronger than classically allowed, violating Bell inequalities. Entanglement is a resource for quantum computation and communication.  
+*Reference:* R. Horodecki, P. Horodecki, M. Horodecki, and K. Horodecki, “Quantum entanglement,” *Rev. Mod. Phys.* **81**, 865 (2009).
+
+**Simple Version**
+
+Imagine two magic dice that always show matching numbers no matter how far apart they are. If you roll one die and see a 6, the other instantly shows a 6, too, even if it’s on the other side of the world. That’s entanglement: the particles are “linked” so that learning about one tells you something about the other, faster than any message could travel.
+
+---
+
+## 8. Measurement and Wavefunction Collapse
+
+**Standard Concept**
+
+Quantum measurement projects a system’s state onto an eigenstate of the measurement operator. The wavefunction collapse postulate states that after measurement, the system instantaneously adopts the eigenstate corresponding to the observed eigenvalue, and subsequent probabilities are computed from that post-measurement state.  
+*Reference:* P. A. M. Dirac, *The Principles of Quantum Mechanics*, 4th ed. (1958), Chapter VIII.
+
+**Simple Version**
+
+Before you peek, a quantum object tries many outfits at once. When you look, it freezes wearing just one outfit. That sudden change is “wavefunction collapse.” The act of checking forces the object to commit to a single choice, like a shy actor stepping into the spotlight and picking a costume to wear.
+
+---
+
+## 9. Hilbert Space and Bra-Ket Notation
+
+**Standard Concept**
+
+Quantum states reside in a complex Hilbert space, a complete vector space with an inner product. Dirac’s bra-ket notation uses $|\psi\rangle$ for state vectors (kets) and $\langle\phi|$ for dual vectors (bras). Inner products $\langle\phi|\psi\rangle$ produce complex numbers representing amplitudes, and linear operators act on kets to change states or extract observables.  
+*Reference:* P. A. M. Dirac, *The Principles of Quantum Mechanics*, 4th ed. (1958), Chapter II.
+
+**Simple Version**
+
+Think of a Hilbert space as a big room where every point is a possible state for your quantum toy. Bra-ket notation is just a fancy way of writing “vectors” and “functions” that live in this room. A “ket” $|\psi\rangle$ is like pointing to a spot in the room, while a “bra” $\langle\phi|$ is like shining a beam that measures something about that spot. When you combine them $\langle\phi|\psi\rangle$, you get a number that tells you how much the beam and spot agree.
+
+---
+
+## 10. Feynman Path Integrals
+
+**Standard Concept**
+
+The path integral formulation expresses a quantum amplitude as a sum over all possible paths connecting initial and final states:
+$$
+\langle x_f, t_f | x_i, t_i \rangle = \int \mathcal{D}[x(t)] \; e^{\frac{i}{\hbar} S[x(t)]}.
+$$
+Here, $S[x(t)]$ is the classical action. Each path contributes a phase $e^{iS/\hbar}$, and observable quantities emerge from interference among these paths.  
+*Reference:* R. P. Feynman and A. R. Hibbs, *Quantum Mechanics and Path Integrals* (1965), Chapter 2.
+
+**Simple Version**
+
+To figure out where a quantum particle goes, imagine it trying every possible route from start to finish. Some paths wiggle a lot, others are straight. Each path gets a special “phase tag,” and when you add up all the tags, most cancel out except the ones near the classical path. It’s like having a zillion reporters shout what route the particle took; the voices that agree get louder while the rest cancel each other out, revealing the most likely path.
+
+---
+


### PR DESCRIPTION
## Summary
- Hide root Stack header and centralize styling in concepts stack
- Set a consistent "concepts" title for the concepts index screen
- Link Double-Slit Experiment so it appears in the concepts index

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68b72ff0c16c83228242699994e4cc79