### PR TITLE
Fix Babel configuration for NativeWind and Reanimated

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,7 +1,9 @@
 module.exports = function (api) {
   api.cache(true);
   return {
-    presets: ['babel-preset-expo'],
-    plugins: ['nativewind/babel'],
+    // Load Expo defaults and NativeWind support as presets
+    presets: ['babel-preset-expo', 'nativewind/babel'],
+    // React Native Reanimated plugin must be listed last
+    plugins: ['react-native-reanimated/plugin'],
   };
 };


### PR DESCRIPTION
## Summary
- configure NativeWind as a preset instead of a plugin
- add React Native Reanimated plugin

## Testing
- `npm run web` *(fails: Domain forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b85a36266c83229402c5901bf3c9ed